### PR TITLE
escape dots in volume name

### DIFF
--- a/aws/volume.go
+++ b/aws/volume.go
@@ -88,7 +88,8 @@ func createVolumeName(path *string) (string, error) {
 		return "", errors.New("cannot create volume name from empty string.")
 	}
 
-	tokens := strings.Split(*path, "/")
+	noDots := strings.Replace(*path, ".", "/", -1)
+	tokens := strings.Split(noDots, "/")
 
 	parts := []string{}
 	for _, token := range tokens {

--- a/aws/volume_test.go
+++ b/aws/volume_test.go
@@ -99,3 +99,18 @@ func TestCreateVolumeNameSlash(t *testing.T) {
 		t.Errorf("expect '%s', but actual '%s'.", expected, actual)
 	}
 }
+
+func TestCreateVolumeNameDots(t *testing.T) {
+
+	expected := "VarRunDockerSock"
+	input := "/var/run/docker.sock"
+
+	actual, err := createVolumeName(&input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if actual != expected {
+		t.Errorf("expect '%s', but actual '%s'.", expected, actual)
+	}
+}


### PR DESCRIPTION
In task definition, if volume path contains ".", for example, 

```yml
volumes:
    - /var/run/docker.sock:/var/run/docker.sock
```

then following error occurs.

ERRO[0000] ClientException: volume.name contains invalid characters.

This is due to the volume name contains invalid character: ".".