### PR TITLE
fix register task definition when WorkingDirectory is empty

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -230,7 +230,6 @@ func createContainerDefinition(con *ContainerDefinition) (*ecs.ContainerDefiniti
 		Privileged:             aws.Bool(con.Privileged),
 		ReadonlyRootFilesystem: aws.Bool(con.ReadonlyRootFilesystem),
 		Ulimits:                toUlimits(con.Ulimits),
-		WorkingDirectory:       aws.String(con.WorkingDirectory),
 	}
 
 	if con.Hostname != "" {
@@ -244,6 +243,9 @@ func createContainerDefinition(con *ContainerDefinition) (*ecs.ContainerDefiniti
 	}
 	if con.User != "" {
 		cd.User = aws.String(con.User)
+	}
+	if con.WorkingDirectory != "" {
+		cd.WorkingDirectory = aws.String(con.WorkingDirectory)
 	}
 
 	return cd, volumes, nil


### PR DESCRIPTION
Hello @stormcat24 san.

I found that registering task definition will fail when `working_dir` is empty. So I fixed it. Please review this.

Thank you for great tool!