### PR TITLE
Fix cause panic when using EC2Role credential

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -20,10 +20,14 @@ type AwsManager struct {
 
 func NewAwsManager(region string) *AwsManager {
 
+	sess := session.New()
 	cred := credentials.NewChainCredentials([]credentials.Provider{
 		&credentials.EnvProvider{},
 		&credentials.SharedCredentialsProvider{Filename: "", Profile: ""},
-		&ec2rolecreds.EC2RoleProvider{ExpiryWindow: 5 * time.Minute},
+		&ec2rolecreds.EC2RoleProvider{
+			Client:       ec2metadata.New(sess),
+			ExpiryWindow: 5 * time.Minute,
+		},
 	})
 
 	conf := aws.NewConfig().WithCredentials(cred).WithMaxRetries(aws.UseServiceDefaultRetries).WithRegion(region)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ecs"


### PR DESCRIPTION
Cause panic when using EC2 Role credential.

```
time="2016-07-04T07:12:44Z" level=info msg="Start apply Task definitions..." 
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x78d060]

goroutine 1 [running]:
panic(0xa06460, 0xc8200120f0)
	/usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata.(*EC2Metadata).GetMetadata(0x0, 0xb77e80, 0x19, 0x0, 0x0, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/ec2metadata/api.go:25 +0x1b0
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds.requestCredList(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider.go:133 +0x74
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds.(*EC2RoleProvider).Retrieve(0xc820011e00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider.go:89 +0x8b
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials.(*ChainProvider).Retrieve(0xc820011e60, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials/chain_provider.go:75 +0x122
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials.(*Credentials).Get(0xc820014c60, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/credentials/credentials.go:185 +0x121
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/private/signer/v4.(*signer).sign(0xc82013a8e0, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/private/signer/v4/v4.go:182 +0x3c5
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/private/signer/v4.Sign(0xc820188000)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/private/signer/v4/v4.go:155 +0x1fc
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/request.(*HandlerList).Run(0xc820188138, 0xc820188000)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/request/handlers.go:136 +0xc3
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/request.(*Request).Sign(0xc820188000, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/request/request.go:216 +0xce
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/request.(*Request).Send(0xc820188000, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/aws/request/request.go:261 +0x6f4
github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/service/ecs.(*ECS).RegisterTaskDefinition(0xc82002a148, 0xc820017780, 0x410b22, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go:740 +0x4f
github.com/stormcat24/ecs-formation/aws.(*EcsApi).RegisterTaskDefinition(0xc82002a150, 0xc820113e8e, 0x8, 0xc82002a140, 0x1, 0x1, 0xebcb48, 0x0, 0x0, 0xe96450, ...)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/aws/ecs_api.go:190 +0x145
github.com/stormcat24/ecs-formation/task.(*TaskDefinitionController).ApplyTaskDefinitionPlan(0xc820148120, 0xc8200cdd60, 0x1, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/task/task.go:158 +0x452
github.com/stormcat24/ecs-formation/task.(*TaskDefinitionController).ApplyTaskDefinitionPlans(0xc820148120, 0xc82002a120, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/task/task.go:122 +0x1f7
github.com/stormcat24/ecs-formation/operation.doTask(0xc8200e65a0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/operation/task.go:57 +0x6c0
github.com/stormcat24/ecs-formation/vendor/github.com/codegangsta/cli.Command.Run(0xaf7c18, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0xb7a280, 0x1b, 0xb7a2a0, ...)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/codegangsta/cli/command.go:137 +0x1081
github.com/stormcat24/ecs-formation/vendor/github.com/codegangsta/cli.(*App).Run(0xc8200e6360, 0xc82000a0a0, 0x5, 0x5, 0x0, 0x0)
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/vendor/github.com/codegangsta/cli/app.go:175 +0xffa
main.main()
	/home/kjmkznr/go/src/github.com/stormcat24/ecs-formation/main.go:28 +0x23c
```

Link: https://github.com/aws/aws-sdk-go/issues/430